### PR TITLE
add bins count on map

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,5 @@
 import fetch from "node-fetch";
-import binsData from "../src/bins";
+import data from "../src/bins";
 import Bin from "../components/bin";
 import React from "react";
 import Footer from "../components/footer";
@@ -53,7 +53,7 @@ export async function getStaticProps() {
   const ni = niAuthorityCodes();
   return {
     props: {
-      bins: binsData.bins.map((bin) => {
+      bins: data.bins.map((bin) => {
         bin.fileName = `${process.env.NEXT_PUBLIC_ASSET_ROOT}${bin.fileName}`
         return bin
       }),

--- a/pages/map.js
+++ b/pages/map.js
@@ -1,16 +1,15 @@
 import React from "react";
-import A from "../components/a";
 import P from "../components/p";
 import H2 from "../components/h2";
 import Footer from "../components/footer";
-import Contact from "../components/contact";
+import data from "../src/bins"
 
 const Map = () => {
   return (
     <>
       <div className="lg:w-2/3 lg:ml-40 px-5 pt-5 lg:px-0 text-2xl font-rubik">
         <H2>Map</H2>
-        <P>Bins catalogued so far</P>
+        <P>{data.bins.length} bins catalogued so far</P>
         <img src="/images/map.svg" />
         <Footer />
       </div>


### PR DESCRIPTION
This commit adds a count of the bins catalogued to the map page which is
ran from the bins file in the /src directory.

![Screenshot 2020-10-20 at 09 58 09](https://user-images.githubusercontent.com/449004/96564211-c7c92f80-12ba-11eb-9c81-52ac546654a1.png)